### PR TITLE
Add suport for lambdalisue/jupyter-vim-binding support

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -392,3 +392,14 @@ div.CodeMirror-selected {background: rgba(221, 240, 255, 0.19) !important;}
 .cm-s-default span.cm-header {color: #CF4A4C;}
 .cm-s-default span.cm-variable-2 {color: #7587A6;}
 .cm-s-default span.cm-comment {color: #7F7A80;}
+
+/*
+  lambdalisue/jupyter-vim-binding support
+*/
+
+.edit_mode .cell.selected .CodeMirror.CodeMirror-focused.cm-fat-cursor {
+  background-color: #141414;
+}
+.edit_mode .cell.selected .CodeMirror.CodeMirror-focused:not(.cm-fat-cursor) {
+  background-color: #424242;
+}


### PR DESCRIPTION
See how it looks:

Insert mode:
![pazymejimas_001](https://cloud.githubusercontent.com/assets/297583/24854548/87224b22-1de7-11e7-9feb-361d8d433de7.png)

Normal mode:
![pazymejimas_002](https://cloud.githubusercontent.com/assets/297583/24854553/8b015a08-1de7-11e7-8c9d-79429b075dab.png)


See:
https://github.com/lambdalisue/jupyter-vim-binding
https://github.com/lambdalisue/jupyter-vim-binding/blob/master/vim_binding.css